### PR TITLE
add yml file to build and release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,29 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*' # Trigger on version tags (e.g., v1.0.0)
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Set up MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build solution
+        run: msbuild ExpansionExplorer.sln /p:Configuration=Release
+
+      - name: Upload EXE to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            **\bin\Release\net*\*.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and releasing the project. The workflow is triggered by version tags or manual dispatch and automates the build and release process for the application.

### New GitHub Actions Workflow:

* `.github/workflows/build-and-release.yml`: Added a workflow named "Build and Release" that:
  - Triggers on version tags (e.g., `v1.0.0`) or manual dispatch.
  - Runs on a `windows-latest` environment to build the solution using MSBuild.
  - Uploads the built `.exe` files from the `Release` directory to a GitHub release using the `softprops/action-gh-release` action.