### PR TITLE
Topic/kawahara/fix yml file

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Restore NuGet packages
         run: dotnet restore ExpansionExplorer.sln
 
+      - name: Set up MSBuild
+        uses: microsoft/setup-msbuild@v2 # Set up MSBuild for building .NET projects
+
       - name: Build solution
         run: msbuild ExpansionExplorer.sln /p:Configuration=Release
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,8 +14,13 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
 
-      - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x  # Specify the .NET version to use
+
+      - name: Restore NuGet packages
+        run: dotnet restore ExpansionExplorer.sln
 
       - name: Build solution
         run: msbuild ExpansionExplorer.sln /p:Configuration=Release

--- a/GUIExplorer.WPF/GUIExplorer.WPF.csproj
+++ b/GUIExplorer.WPF/GUIExplorer.WPF.csproj
@@ -16,4 +16,8 @@
     <Folder Include="Src\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3179.45" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This pull request introduces updates to the build pipeline and project dependencies to support .NET 8.0 and integrate the `Microsoft.Web.WebView2` package. These changes aim to modernize the development environment and enhance project capabilities.

### Build pipeline updates:

* [`.github/workflows/build-and-release.yml`](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bR17-R26): Added steps to set up .NET 8.0, restore NuGet packages, and clarified the use of MSBuild for building .NET projects. This ensures compatibility with the latest .NET version and streamlines the build process.

### Project dependency updates:

* [`GUIExplorer.WPF/GUIExplorer.WPF.csproj`](diffhunk://#diff-b1389d3a3dbdd0a1347e4d204e62692aac32a12214c164f74c281423498612adR19-R22): Added a reference to the `Microsoft.Web.WebView2` package, version `1.0.3179.45`, enabling the use of modern WebView2 features in the WPF project.