### PR TITLE
Fix file path separator in build and release workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -32,6 +32,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            **\bin\Release\net*\*.exe
+            **/bin/Release/net*/**/*.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build-and-release.yml` file. The change updates the file path pattern for release artifacts to use forward slashes for consistency and compatibility across environments.