### PR TITLE
Topic/kawahara/fix yml file

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -32,6 +32,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            **\bin\Release\net*\*.exe
+            **/bin/Release/net*/**/*.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -28,10 +28,17 @@ jobs:
       - name: Build solution
         run: msbuild ExpansionExplorer.sln /p:Configuration=Release
 
-      - name: Upload EXE to release
+      - name: Publish GUIExplorer.WPF
+        run: dotnet publish GUIExplorer.WPF/GUIExplorer.WPF.csproj -c Release -r win-x64 --self-contained false -o publish
+
+      # Create a ZIP file of the published output
+      - name: Create release ZIP
+        run: Compress-Archive -Path publish\* -DestinationPath GUIExplorer.WPF.zip
+
+      # Upload the ZIP file to the GitHub release
+      - name: Upload ZIP to release
         uses: softprops/action-gh-release@v2
         with:
-          files: |
-            **/bin/Release/net*/**/*.exe
+          files: GUIExplorer.WPF.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the build and release workflow to improve the publishing process for the `GUIExplorer.WPF` application. The changes replace the previous method of uploading a single executable file with a new process that publishes the application, creates a ZIP file of the published output, and uploads the ZIP file to the GitHub release.

### Workflow improvements:

* Updated the build-and-release workflow in `.github/workflows/build-and-release.yml` to use the `dotnet publish` command for building the `GUIExplorer.WPF` project, targeting `win-x64` with a non-self-contained configuration.
* Added a step to create a ZIP file (`GUIExplorer.WPF.zip`) containing the published output.
* Modified the release upload step to upload the newly created ZIP file instead of individual executable files.